### PR TITLE
Check containership version before accepting myriad-kv subscriptions

### DIFF
--- a/lib/api-bridge.js
+++ b/lib/api-bridge.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const EventEmitter = require('events');
 const net = require('net');
 const request = require('request');
+const semver = require('semver');
 
 const ApiImplementation = require('@containership/containership.abstraction.api');
 
@@ -169,19 +170,28 @@ class ContainershipApiBridge extends ApiImplementation {
 
     // Returns an event emitter.
     subscribeDistributedKey(pattern) {
+        const attributes = this.core.cluster.legiond.get_attributes();
+        const containership_version = _.get(attributes, 'metadata.containership.version');
+
         const ee = new EventEmitter();
 
-        const command = pattern ? `SUBSCRIBE ${pattern}` : `SUBSCRIBE`;
+        if(containership_version && semver.gte(containership_version, '1.8.0')) {
+            const command = pattern ? `SUBSCRIBE ${pattern}` : `SUBSCRIBE`;
 
-        this.makeSocketRequest(command, (err, data) => {
-            if(err) {
-                ee.emit('error', JSON.stringify({
-                    error: err.message
-                }));
-            } else {
-                ee.emit('message', data);
-            }
-        }, false);
+            this.makeSocketRequest(command, (err, data) => {
+                if(err) {
+                    ee.emit('error', JSON.stringify({
+                        error: err.message
+                    }));
+                } else {
+                    ee.emit('message', data);
+                }
+            }, false);
+        } else {
+            ee.emit('error', JSON.stringify({
+                error: 'Containership version 1.8.0 or greater required for subscribing to myriad-kv changes!'
+            }));
+        }
 
         return ee;
     }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@containership/containership.abstraction.api": "git+https://5fe3d6da9bd8b65f13abbbfb608aba1eab5d44d8:x-oauth-basic@github.com/containership/containership.abstraction.api",
     "lodash": "^4.17.4",
-    "request": "^2.79.0"
+    "request": "^2.79.0",
+    "semver": "^5.3.0"
   },
   "devDependencies": {
     "eslint": "^3.19.0"


### PR DESCRIPTION
Ensures containership version 1.8.0 or higher is running before accepting myriad-kv subscriptions